### PR TITLE
[Feature] Let the user change the project being translated after running out of text to translate

### DIFF
--- a/Bot.js
+++ b/Bot.js
@@ -128,7 +128,7 @@ tgBot.on("callback_query", (tgMsg) => {
 });
 
 function setProject(user, tgMsg){
-	let match = mediaWikiAPI.getMessageGroups().filter(item => item.label==tgMsg.text);
+	mediaWikiAPI.getMessageGroups(result => {let match=result.filter(item => item.label==tgMsg.text);
 	if(match.length){
 		mediaWikiAPI.getUntranslatedMessages(null, null, match[0].id);
 		user.state = flags.RESPONSE_MODE;
@@ -136,6 +136,7 @@ function setProject(user, tgMsg){
 	else{
 		tgBot.sendMessage(user.id, "Could not find the specified project, please use it's official name"); 
 	}
+	});
 }
 
 function showMT(user) {
@@ -464,7 +465,7 @@ function loadUntranslated(user, cb) {
             cb(user.loadedMwMessages)
         } else
             tgBot.sendMessage(user.id, "Nothing to translate!\nWhich project would you like to translate next?");
-	    user.state=SET_PROJECT;
+	    user.state=flags.SET_PROJECT;
     });
 }
 

--- a/Bot.js
+++ b/Bot.js
@@ -58,6 +58,9 @@ function processTgMessage(tgMsg) {
                 helpFunction(tgMsg);
                 return;
             }
+            else if (user.state === flags.SET_PROJECT) {
+		setProject(user, tgMsg);
+	    }
             else {
                 //
 
@@ -123,6 +126,17 @@ tgBot.on("callback_query", (tgMsg) => {
         showAndCacheSimilar(user);
     }
 });
+
+function setProject(user, tgMsg){
+	let match = mediaWikiAPI.getMessageGroups().filter(item => item.label==tgMsg.text);
+	if(match.length){
+		mediaWikiAPI.getUntranslatedMessages(null, null, match[0].id);
+		user.state = flags.RESPONSE_MODE;
+	}
+	else{
+		tgBot.sendMessage(user.id, "Could not find the specified project, please use it's official name"); 
+	}
+}
 
 function showMT(user) {
     tgBot.sendMessage(user.id, user.mt);
@@ -449,8 +463,8 @@ function loadUntranslated(user, cb) {
         if (user.loadedMwMessages.length) {
             cb(user.loadedMwMessages)
         } else
-            tgBot.sendMessage(user.id, "Nothing to translate!");
-
+            tgBot.sendMessage(user.id, "Nothing to translate!\nWhich project would you like to translate next?");
+	    user.state=SET_PROJECT;
     });
 }
 

--- a/Bot.js
+++ b/Bot.js
@@ -131,10 +131,13 @@ tgBot.on("callback_query", (tgMsg) => {
 });
 
 function setProject(user, tgMsg){
-	mediaWikiAPI.getMessageGroups(result => {let match=result.filter(item => item.label==tgMsg.text);
+	mediaWikiAPI.getMessageGroups(result => {
+	let match=result.filter(item => item.label==tgMsg.text);
 	if(match.length){
 		mediaWikiAPI.getUntranslatedMessages(null, null, match[0].id);
 		user.state = flags.RESPONSE_MODE;
+		tgBot.sendMessage(user.id, "You are now translating " + match[0].label);
+		trans(user, tgMsg);
 	}
 	else{
 		tgBot.sendMessage(user.id, "Could not find the specified project, please use it's official name"); 

--- a/MediaWikiAPI.js
+++ b/MediaWikiAPI.js
@@ -24,11 +24,7 @@ return function (languageCode, cb, projCode=null) {
                 format: "json",
                 prop: "",
                 list: "messagecollection",
-<<<<<<< HEAD
                 mcgroup: projectCode,
-=======
-                mcgroup: "out-osm-0-all",
->>>>>>> upstream/master
                 mclanguage: languageCode,
                 mclimit: 10, // TODO: Make configurable
                 mcfilter: "!optional|!ignored|!translated"

--- a/MediaWikiAPI.js
+++ b/MediaWikiAPI.js
@@ -11,7 +11,12 @@ const OauthApi = require("./Oauth.js");
 
 const auth = OauthApi.cryptoHashFunction();
 
-exports.getUntranslatedMessages = function (languageCode, cb) {
+exports.getUntranslatedMessages = (function(){
+let projectCode="tsint-0-all";
+return function (languageCode, cb, projCode) {
+    if(projCode){
+	projectCode=projCode;
+    }else{
     request.post({
             url: apiUrl,
             form: {
@@ -19,7 +24,7 @@ exports.getUntranslatedMessages = function (languageCode, cb) {
                 format: "json",
                 prop: "",
                 list: "messagecollection",
-                mcgroup: "tsint-0-all",
+                mcgroup: projectCode,
                 mclanguage: languageCode,
                 mclimit: 5, // TODO: Make configurable
                 mcfilter: "!optional|!ignored|!translated"
@@ -30,7 +35,8 @@ exports.getUntranslatedMessages = function (languageCode, cb) {
             cb(mwMessageCollection);
         }
     );
-};
+}}
+})();
 
 
 
@@ -134,6 +140,21 @@ exports.getMT = function (title, cb) {
                 cb(true,translationaids.helpers.mt[0].target);
 
             }
+        }
+    );
+};
+
+exports.getMessageGroups= function(cb){
+    request.post({
+            url: apiUrl,
+            form: {
+                action: "query",
+                format: "json",
+                meta: "messagegroup",
+		mgprop: "id%7Clabel"
+            }
+        }, (error, response, body) => {
+            cb(JSON.parse(body).query.messagegroups);
         }
     );
 };

--- a/MediaWikiAPI.js
+++ b/MediaWikiAPI.js
@@ -150,8 +150,7 @@ exports.getMessageGroups= function(cb){
             form: {
                 action: "query",
                 format: "json",
-                meta: "messagegroup",
-		mgprop: "id%7Clabel"
+                meta: "messagegroups"
             }
         }, (error, response, body) => {
             cb(JSON.parse(body).query.messagegroups);

--- a/MediaWikiAPI.js
+++ b/MediaWikiAPI.js
@@ -13,7 +13,7 @@ const auth = OauthApi.cryptoHashFunction();
 
 exports.getUntranslatedMessages = (function(){
 let projectCode="tsint-0-all";
-return function (languageCode, cb, projCode) {
+return function (languageCode, cb, projCode=null) {
     if(projCode){
 	projectCode=projCode;
     }else{

--- a/flags.json
+++ b/flags.json
@@ -5,5 +5,6 @@
  "RESPONSE_MODE" : "waitForTranslation",
  "READY_MODE" : "readyToTrans",
  "VERIFIER_MODE" : "waitForVerifier",
- "UPDATE_LANG": "updatelanguage"
+ "UPDATE_LANG": "updatelanguage",
+ "SET_PROJECT": "setProject"
 }


### PR DESCRIPTION
If there's no more strings/text on the project being translated by the bot, the bot will prompt the user to enter the label of the project the user wants to translate next. If the label introduced matches the label of any translation project, the bot will resume the usual translation flow now translating text from the new project.

I'm not sure if it works because I haven't been able to get the project to run since the token change (also, the bot is probably being run on a server), I could try to get it to run after a few days (so it's not running 24/7 on the server anymore) and report back.