### PR TITLE
Improve user flow and remove a hardcoded constant from the code

### DIFF
--- a/Bot.js
+++ b/Bot.js
@@ -428,7 +428,7 @@ function showUnTrans(user, tgMsg) {
 
 function trans(user, tgMsg) {
     user.state = flags.RESPONSE_MODE;
-    if (user.currentMwMessageIndex === 10 || user.loadedMwMessages.length === 0) {
+    if (user.currentMwMessageIndex === user.loadedMwMessages.length || user.loadedMwMessages.length === 0) {
 
         loadUntranslated(user, (loadedMwMessages, flag) => {
             if(flag){


### PR DESCRIPTION
Currently, if the bot gets into the edge case of there being only n€[1,9] messages left to translate in the project being currently translated, when it gets to the last message it'll pass the `user.currentMwMessageIndex === 10` check.

At this point I'm not sure what will happen as I haven't been able to reproduce this scenario but by reading the code one possibility is that the check inside `processTgMessage` would fail, thus triggering the function `helpFunction` and leading eventually to the execution of `trans` which will lead to the execution of `breakPoint` which will then lead to the excution of `trans` again, causing an infinite loop.

Another possibility is that eventually the error would be corrected but the user would have been required to go through a few interactions like clicking "Start Translating" before getting the "Nothing more to translate" message.

With this simple fix the bot should process correctly the edge case described and also we eliminate that magic number/arbitrary constant from the code, so if in a future this number needs to be changed there won't be redundancies to take care of.

This fix hasn't been properly tested as I can't run the bot.